### PR TITLE
[Add] uuid 패키자 추가로 인한 isClear 업데이트 및 Todo 삭제

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-router-dom": "^6.6.2",
         "react-scripts": "5.0.1",
         "sass": "^1.57.1",
+        "uuid": "^9.0.0",
         "web-vitals": "^2.1.4"
       }
     },
@@ -15656,6 +15657,14 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -16666,9 +16675,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -28645,6 +28654,13 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "source-list-map": {
@@ -29397,9 +29413,9 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-to-istanbul": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-router-dom": "^6.6.2",
     "react-scripts": "5.0.1",
     "sass": "^1.57.1",
+    "uuid": "^9.0.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/page/Home.js
+++ b/src/page/Home.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { axios_get, axios_post } from "../api/api";
+import { v4 as uuidv4 } from "uuid";
+
 import TodoInput from "./HomeComponents/TodoInput";
 import TodoList from "./HomeComponents/TodoList";
 import SimpleCalendar from "./HomeComponents/SimpleCalendar";
@@ -42,6 +44,7 @@ export default function Home() {
         {
           todo,
           isClear: false,
+          tempId: uuidv4(),
         },
       ]);
     } else {
@@ -50,6 +53,7 @@ export default function Home() {
         {
           todo,
           isClear: false,
+          tempId: uuidv4(),
         },
       ]);
     }

--- a/src/page/HomeComponents/TodoInput.js
+++ b/src/page/HomeComponents/TodoInput.js
@@ -14,14 +14,18 @@ export default function TodoInput({ addTodo }) {
 
   const changeAddState = () => {
     if (addState === "TODO") {
-      setAddState("습관");
+      setAddState("HABIT");
     } else {
       setAddState("TODO");
     }
   };
+
+  const handleAddTodo = () => {
+    addTodo(addState, todoText);
+    setTodoText("");
+  };
   // TODO 엔터를 입력해도 추가될 수 있도록 구현
   // TODO 시간 설정할 수 있는 토스트 창 추가
-  // TODO 입력 시 todoText 초기화 시키기
 
   return (
     <div className="InputBox">
@@ -40,7 +44,7 @@ export default function TodoInput({ addTodo }) {
       ></input>
       <div>
         <AccessAlarmIcon />
-        <AddIcon onClick={() => addTodo(addState, todoText)} />
+        <AddIcon onClick={handleAddTodo} />
       </div>
     </div>
   );

--- a/src/page/HomeComponents/TodoList.js
+++ b/src/page/HomeComponents/TodoList.js
@@ -2,10 +2,15 @@ export default function TodoList({ category, data, setData }) {
   // TODO 삭제버튼 커스터마이징
   // TODO TODO 완료 상태 여부 판단(update)
 
-  const handleUpdate = (e) => {
+  const handleDelete = (targetId) => {
+    const deletedData = data.filter((val) => val.tempId !== targetId);
+    setData(deletedData);
+  };
+
+  const handleUpdate = (targetId) => {
     // 추후에 id 값으로 비교해서 업데이트 하기
     const updateData = data.map((val) => {
-      if (val.todo === e.target.innerText.trim()) {
+      if (val.tempId === targetId) {
         val.isClear = !val.isClear;
       }
       return val;
@@ -20,12 +25,17 @@ export default function TodoList({ category, data, setData }) {
         <span>등록된 일이 없어요</span>
       ) : (
         <div className="list">
-          {data.map((val, index) => {
+          {data.map((val) => {
             return (
-              <div className="element" key={index}>
-                <button className="DeleteButton">X</button>
+              <div className="element" key={val.tempId}>
+                <button
+                  className="DeleteButton"
+                  onClick={() => handleDelete(val.tempId)}
+                >
+                  X
+                </button>
                 <span
-                  onClick={(e) => handleUpdate(e)}
+                  onClick={() => handleUpdate(val.tempId)}
                   style={{
                     textDecoration: val.isClear ? "line-through" : "none",
                   }}


### PR DESCRIPTION
uuid 패키지를 통한 각각 todo의 임시 아이디를 부여하여 낙관적 업데이트 된 todo에 고유성을 부여해 todo 진행상태 업데이트 및 todo 삭제를 가능할 수 있도록 만들었습니다.

문제점.

1. 낙관적 업데이트로 사용된 uuid는 언제까지 지속될 것이며 DB에 저장된 이후에는 임시 아이디가 아닌 실제 아이디를 통해 삭제 및 업데이트를 해야하는 문제점이 있습니다.

2. 1번의 문제점으로 인해 낙관적 업데이트를 포기하는 방법을 선택하거나 todo를 수정하고 나면 confirm 버튼을 만들어서 DB에 확실하게 업로드 해야하는 부분 중 선택해야 할 것 같습니다.   


홈에서 추가되어야 하는 부분

todo 추가 시 시간설정을 할 수 있는 toast 팝업 창 구현
시간 설정이 되었을 때 시간설정이 된 todo는 어떻게 보여줄지 UI/UX 생각하기
SimpleCalendar 혹은 ModalCalendar에서 날짜 변경시 todo 목록을 계속해서 읽어와야하는데 이때의 트래픽 처리
검색의 debounce처럼 마지막에 선택된 날짜에 대해서만 데이터 수집을 요구하여 로딩을 실현하는 방향으로 생각중 

문제점에 대해서 의견을 달아주세요~