### PR TITLE
[Add] 친구 Todo 보는 화면 추가 / 응원할 Todo 선택 추가

### DIFF
--- a/src/page/FindFriends.js
+++ b/src/page/FindFriends.js
@@ -9,6 +9,10 @@ import SearchIcon from "@mui/icons-material/Search";
 import tempImg1 from "../assets/images/kim.jpg";
 import tempImg2 from "../assets/images/yena.jpg";
 import Tile from "../components/Tile";
+import SimpleCalendar from "./HomeComponents/SimpleCalendar";
+import TodoList from "./HomeComponents/TodoList";
+import DateProvider from "../contexts/dateProvider";
+import { v4 } from "uuid";
 const dummyData = [
   {
     profileImg: tempImg1,
@@ -21,11 +25,39 @@ const dummyData = [
     name: "최예나",
   },
 ];
+const dummyToDo = [
+  {
+    todo: "TODO1",
+    limitTime: "17:00",
+    isClear: true,
+    tempId: v4(),
+  },
+  {
+    todo: "TODO2",
+    limitTime: "22:00",
+    isClear: false,
+    tempId: v4(),
+  },
+];
+
+const dummyHabit = [
+  {
+    todo: "HABIT1",
+    limitTime: null,
+    isClear: false,
+    tempId: v4(),
+  },
+];
 
 export default function FindFriends() {
   let navigate = useNavigate();
   const [typingAnimationEnd, setTypingAnimationEnd] = useState(false);
   const [fadeAnimationEnd, setFadeAnimationEnd] = useState(false);
+  const [fadeAnimationEnd2, setFadeAnimationEnd2] = useState(false);
+  const [selectedFriend, setSelectedFriend] = useState({
+    profileImg: null,
+    memId: null,
+  });
   const [startX, setStartX] = useState(0);
   const [searchText, setSearchText] = useState("");
   const inputRef = useRef();
@@ -35,6 +67,9 @@ export default function FindFriends() {
   const [fadeAnimation, fadeClear] = useTimeout(() => {
     setFadeAnimationEnd(true);
   }, 4400);
+  const [fadeAnimation2, fadeClear2] = useTimeout(() => {
+    setFadeAnimationEnd2(true);
+  }, 1000);
 
   useSlideBack("touchmove", startX, () => {
     navigate(-1);
@@ -49,12 +84,22 @@ export default function FindFriends() {
     setSearchText(e.target.value);
   };
 
-  const handleMoveWrite = (profileImg, memId) => {
+  const handleSelectFriend = (profileImg, memId) => {
+    setSelectedFriend({
+      profileImg,
+      memId,
+    });
+    fadeAnimation2();
+  };
+
+  const handleMoveWrite = (todoId, type, category, todo) => {
     navigate("/write", {
       state: {
-        profileImg,
-        memId,
+        profileImg: selectedFriend.profileImg,
+        memId: selectedFriend.memId,
         location: "findFriends",
+        todo,
+        category,
       },
     });
   };
@@ -83,8 +128,13 @@ export default function FindFriends() {
           <h3 className="typewriter">편지를 쓸 친구를 찾고 선택해보세요</h3>
         </div>
         <div
-          className="fadeInDiv"
-          style={{ display: !typingAnimationEnd ? "none" : "block" }}
+          className={`${
+            selectedFriend.memId !== null ? "clearDiv" : "fadeInDiv"
+          }`}
+          style={{
+            display:
+              !typingAnimationEnd || fadeAnimationEnd2 ? "none" : "block",
+          }}
         >
           <div className="searchBar">
             <input
@@ -105,11 +155,39 @@ export default function FindFriends() {
               memId={memId}
               name={name}
               type="check"
-              handleClick={() => handleMoveWrite(profileImg, memId)}
+              handleClick={() => handleSelectFriend(profileImg, memId)}
             />
           ))}
         </div>
       </div>
+      <DateProvider>
+        <div
+          className="fadeInDiv"
+          style={{ display: !fadeAnimationEnd2 ? "none" : "block" }}
+        >
+          <div className="Mainheader">
+            <SimpleCalendar />
+            <hr />
+          </div>
+          <div id="homeContents">
+            <span style={{ fontSize: "18px" }}>
+              <strong>{selectedFriend.memId}</strong> 님의 할일 목록
+            </span>
+            <TodoList
+              category={"TODO"}
+              data={dummyToDo}
+              handleClick={handleMoveWrite}
+              my={false}
+            />
+            <TodoList
+              category={"HABIT"}
+              data={dummyHabit}
+              handleClick={handleMoveWrite}
+              my={false}
+            />
+          </div>
+        </div>
+      </DateProvider>
     </>
   );
 }

--- a/src/page/Home.js
+++ b/src/page/Home.js
@@ -12,6 +12,9 @@ import "../style/index.scss";
 import Calendar from "./HomeComponents/Calendar";
 import TimePickModal from "./HomeComponents/TimePickModal";
 
+// 임시이미지
+import myImg from "../assets/images/chuu.jpg";
+
 export default function Home() {
   const [todos, setTodos] = useState([]);
   const [habits, setHabits] = useState([]);
@@ -63,7 +66,36 @@ export default function Home() {
     }
   };
 
-  const removeTodo = () => {};
+  const handleClick = (targetId, type, category) => {
+    switch (type) {
+      case "DELETE":
+        category === "TODO"
+          ? setTodos(todos.filter((val) => val.tempId !== targetId))
+          : setHabits(habits.filter((val) => val.tempId !== targetId));
+        break;
+      case "UPDATE":
+        category === "TODO"
+          ? setTodos(
+              todos.map((val) => {
+                if (val.tempId === targetId) {
+                  val.isClear = !val.isClear;
+                }
+                return val;
+              })
+            )
+          : setHabits(
+              habits.map((val) => {
+                if (val.tempId === targetId) {
+                  val.isClear = !val.isClear;
+                }
+                return val;
+              })
+            );
+        break;
+      default:
+        alert("오류 발생");
+    }
+  };
 
   // User TODO API 받기
   const getData = async () => {
@@ -83,8 +115,11 @@ export default function Home() {
         <hr />
       </div>
       <div id="homeContents">
-        <TodoList category={"TODO"} data={todos} setData={setTodos} />
-        <TodoList category={"HABIT"} data={habits} setData={setHabits} />
+        <span style={{ fontSize: "18px" }}>
+          <strong>chuu</strong> 님의 할일 목록
+        </span>
+        <TodoList category={"TODO"} data={todos} handleClick={handleClick} />
+        <TodoList category={"HABIT"} data={habits} handleClick={handleClick} />
       </div>
       <CalendarToggle setOpenCalendar={setOpenCalendar} />
       <TodoInput addTodo={addTodo} setOpenTimePicker={setOpenTimePicker} />

--- a/src/page/HomeComponents/SimpleCalendar.js
+++ b/src/page/HomeComponents/SimpleCalendar.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import "../../style/index.scss";
 import { useDate } from "../../contexts/dateProvider";
 
 export default function SimpleCalendar() {

--- a/src/page/HomeComponents/TodoList.js
+++ b/src/page/HomeComponents/TodoList.js
@@ -1,23 +1,5 @@
-export default function TodoList({ category, data, setData }) {
+export default function TodoList({ category, data, handleClick, my = true }) {
   // TODO 삭제버튼 커스터마이징
-  // TODO TODO 완료 상태 여부 판단(update)
-
-  const handleDelete = (targetId) => {
-    const deletedData = data.filter((val) => val.tempId !== targetId);
-    setData(deletedData);
-  };
-
-  const handleUpdate = (targetId) => {
-    // 추후에 id 값으로 비교해서 업데이트 하기
-    const updateData = data.map((val) => {
-      if (val.tempId === targetId) {
-        val.isClear = !val.isClear;
-      }
-      return val;
-    });
-    setData(updateData);
-  };
-
   return (
     <>
       <p style={{ fontSize: "18px", margin: "2px 0px" }}>{category}</p>
@@ -28,14 +10,22 @@ export default function TodoList({ category, data, setData }) {
           {data.map((val) => {
             return (
               <div className="element" key={val.tempId}>
-                <button
-                  className="DeleteButton"
-                  onClick={() => handleDelete(val.tempId)}
-                >
-                  X
-                </button>
+                {my ? (
+                  <button
+                    className="DeleteButton"
+                    onClick={() =>
+                      handleClick(val.tempId, "DELETE", category, val.todo)
+                    }
+                  >
+                    X
+                  </button>
+                ) : (
+                  <div></div>
+                )}
                 <span
-                  onClick={() => handleUpdate(val.tempId)}
+                  onClick={() =>
+                    handleClick(val.tempId, "UPDATE", category, val.todo)
+                  }
                   style={{
                     textDecoration: val.isClear ? "line-through" : "none",
                   }}

--- a/src/page/Write.js
+++ b/src/page/Write.js
@@ -57,6 +57,11 @@ export default function Write() {
           <span>{state.memId}</span>
         </div>
       </div>
+      <div>
+        <span>
+          응원할 {state.category} : {state.todo}
+        </span>
+      </div>
       <div
         style={{
           border: "1px solid black",
@@ -92,11 +97,13 @@ export default function Write() {
         />
       </div>
       <div style={{ display: "flex", justifyContent: "space-around" }}>
-        <FlatButton name="편지쓰기" width="120px" height="50px" />
+        <FlatButton
+          name="편지쓰기"
+          style={{ width: "120px", height: "50px", borderRadius: "12px" }}
+        />
         <FlatButton
           name="편지취소"
-          width="120px"
-          height="50px"
+          style={{ width: "120px", height: "50px", borderRadius: "12px" }}
           onClick={() =>
             state.location === "findFriends" ? navigate(-2) : navigate(-1)
           }

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -26,45 +26,45 @@ $background-color: #fbf8f3;
     height: 80px;
     padding-top: 12px;
     margin: 0px 8px;
-    //HOME 헤더
-    .SimpleCalendar {
+  }
+  //HOME 헤더
+  .SimpleCalendar {
+    display: flex;
+    flex-direction: row;
+    width: -webkit-fill-available;
+    align-items: baseline;
+
+    & > * {
       display: flex;
-      flex-direction: row;
-      width: -webkit-fill-available;
+      flex-wrap: wrap;
+      align-content: center;
+      justify-content: center;
+    }
+
+    & > :nth-child(1) {
+      font-size: 36px;
+      font-weight: 600;
+      flex: 1;
+    }
+
+    & > :nth-child(2) {
+      flex: 2;
+      justify-content: space-around;
       align-items: baseline;
 
-      & > * {
-        display: flex;
-        flex-wrap: wrap;
-        align-content: center;
-        justify-content: center;
+      & > #selectedDay {
+        background-color: $sub-color;
+        color: white;
+        font-size: 32px;
+        border-radius: 50%;
+        padding: 0px 8px;
       }
+    }
 
-      & > :nth-child(1) {
-        font-size: 36px;
-        font-weight: 600;
-        flex: 1;
-      }
-
-      & > :nth-child(2) {
-        flex: 2;
-        justify-content: space-around;
-        align-items: baseline;
-
-        & > #selectedDay {
-          background-color: $sub-color;
-          color: white;
-          font-size: 32px;
-          border-radius: 50%;
-          padding: 0px 8px;
-        }
-      }
-
-      & > :nth-child(3) {
-        font-size: 18px;
-        font-weight: 600;
-        flex: 1;
-      }
+    & > :nth-child(3) {
+      font-size: 18px;
+      font-weight: 600;
+      flex: 1;
     }
   }
   #homeContents {
@@ -729,10 +729,10 @@ $background-color: #fbf8f3;
   left: 50%;
   transform: translate(-50%, -50%);
   text-align: center;
+}
 
-  &.clearDiv {
-    animation: interval-fade-out 1.5s;
-  }
+.clearDiv {
+  animation: interval-fade-out 1.5s;
 }
 
 .fadeInDiv {


### PR DESCRIPTION
친구의 TODO화면과 본인의 TODO 화면을 구분하기 위해 홈화면 상단에 userId를 띄우기로 했습니다.

근데 디자인이 맘에 안들어서 추후에 수정하겠습니다.

Post -> 쓰기버튼 클릭 -> 친구선택 애니매이션 -> 친구선택 -> 친구TODO 선택 -> Write 형태로 편지를 쓸 수 있습니다.

나머지 친구를 선택해서 편지를 쓰게되면 -> 친구 TODO선택화면을 따로 만든뒤 -> Write로 넘어가게 할 예정입니다.

모듈화 및 컴포넌트화가 필요합니다. 혼자 만드니까 진짜 너무 뇌빼고 만든 컴포넌트가 많아서 중복되는 코드가 많습니다. ㅎ 